### PR TITLE
tweak

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -21,6 +21,4 @@ const cli = meow(`
 	}
 });
 
-const fn = cli.flags.ipv4 ? 'v4' : (cli.flags.ipv6 ? 'v6' : 'v4');
-
-publicIp[fn]().then(console.log);
+publicIp[cli.flags.ipv6 ? 'v6' : 'v4']().then(console.log);


### PR DESCRIPTION
It looks like the statement could be made a little bit easier because if it's not v4 and not v6, it uses v4 as fallback. Conclusion, if it's not v6, it's always v4.
